### PR TITLE
Add comment syntax for .res files (#233)

### DIFF
--- a/resources/res_grammar.json
+++ b/resources/res_grammar.json
@@ -27,6 +27,9 @@
                     "include": "#compression"
                 },
                 {
+                    "include": "#comment"
+                },
+                {
                     "include": "#timing"
                 },
                 {
@@ -96,7 +99,12 @@
             "match": "BEST|AUTO|NONE|APLIB|FAST|LZ4W",
             "name": "keyword.control.compresion"
         },
-        "timing": {
+        "comment": {
+            "begin": "\\#",
+            "end": "\\\n",
+            "name": "comment.line.number-sign"
+        },
+	    "timing": {
             "match": "AUTO|NTSC|PAL",
             "name": "keyword.control.timing"
         },


### PR DESCRIPTION
Already added the comment syntax to highlighting rules in order to highlight the comments on our `Sgdk Resource File` files. Related with #233 