### PR TITLE
Added regions and fixed syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This is the change Log of Genesis Code. For more information you can see the [Documentation page](https://zerasul.github.io/genesis-code-docs/).
 
+## 1.3.4
+
+* SGDK resource files now have regions
+    * They start with *#region* / *#pragma region*
+    * They end with *#endregion* / *#pragma endregion*
+* Fixed some syntax highlighting errors related with numbers
+
 ## 1.3.3
 
 * [Added SGDK 1.65 Support](https://github.com/zerasul/genesis-code/issues/277).

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Now you can use the Bitmap Viewer; with some information of the images. You can 
 
 ## Release Notes
 
+### 1.3.4
+
+* SGDK resource files now have regions
+    * They start with *#region* / *#pragma region*
+    * They end with *#endregion* / *#pragma endregion*
+* Fixed some syntax highlighting errors related with numbers
+
 ### 1.3.3
 
 * Added SGDK 1.65 Support.

--- a/package.json
+++ b/package.json
@@ -94,9 +94,8 @@
 		"languages": [
 			{
 				"id": "Sgdk Resource File",
-				"extensions": [
-					".res"
-				]
+				"extensions": [".res"],
+				"configuration": "./resources/language-configuration.json"
 			}
 		],
 		"grammars": [

--- a/resources/language-configuration.json
+++ b/resources/language-configuration.json
@@ -1,0 +1,16 @@
+{
+	"comments": {
+		// symbol used for single line comment. Remove this entry if your language does not support line comments
+		"lineComment": "#",
+	},
+	// symbols that are auto closed when typing
+	"autoClosingPairs": [
+		["\"", "\""]
+	],
+	"folding": {
+		"markers": {
+			"start": "(^\\s*#?region\\b)|(^\\s*#?pragma region\\b)",
+			"end": "(^\\s*#?endregion\\b)|(^\\s*#?pragma endregion\\b)"
+		}
+	}
+}

--- a/resources/res_grammar.json
+++ b/resources/res_grammar.json
@@ -27,6 +27,9 @@
                     "include": "#compression"
                 },
                 {
+                    "include": "#regions"
+                },
+                {
                     "include": "#comment"
                 },
                 {
@@ -92,7 +95,7 @@
             ]
         },
         "number": {
-            "match": "\\d",
+            "match": "([0-9]+\\\n)|(\\ +[0-9]+\\ )|(\t+[0-9]+\\ )|(\\ +[0-9]+\t)|(\t+[0-9]+\t)",
             "name": "constant.numeric.number"
         },
         "height": {
@@ -111,7 +114,12 @@
             "end": "\\\n",
             "name": "comment.line.number-sign"
         },
-	    "timing": {
+        "regions": {
+            "begin": "(\\#region)|(\\#endregion)|(\\#pragma region)|(\\#pragma endregion)",
+            "end": "\\\n",
+            "name": "markup.italic"
+        },
+        "timing": {
             "match": "AUTO|NTSC|PAL",
             "name": "keyword.control.timing"
         },


### PR DESCRIPTION
SGDK resource files now have regions
- #region / #pragma region
- #endregion / #pragma endregion

Fixed some syntax highlighting errors related to the numbers
- 2ADPCM should now be highlighted as expected